### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ OpenAI-compatible client can then query HiveMind via the persona server's REST A
 
 ## Documentation
 
-- [`docs/solver_integration.md`](docs/solver_integration.md) — how the solver
+- [`docs/solver_integration.md`](docs/solver_integration.md): how the solver
   integrates with the OVOS solver framework.
-- [`docs/configuration.md`](docs/configuration.md) — full configuration reference.
+- [`docs/configuration.md`](docs/configuration.md): full configuration reference.
 
 ## Credits
 
 This work was sponsored by VisioLab, part of
-[Royal Dutch Visio](https://visio.org/) — the research and education center for
+[Royal Dutch Visio](https://visio.org/), the research and education center for
 assistive technology for blind and visually impaired people.
 
 ## License

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,9 @@ solver = HiveMindSolver(config={
 |---------------|--------|--------------------------|-------------|
 | `autoconnect` | bool   | `false`                  | Connect automatically at construction time. If `false`, call `solver.connect()` before the first query. |
 | `useragent`   | string | `"ovos-hivemind-solver"` | User-agent string sent to the hub in the handshake. |
+
+| Key           | Type   | Default                  | Description |
+|---------------|--------|--------------------------|-------------|
 | `site_id`     | string | from identity file       | Site ID for the connection. Overrides the value in the identity file. |
 | `lang`        | string | `"en-us"`                | Default language when no `lang` is present in the query context. |
 
@@ -50,4 +53,7 @@ hivemind-client set-identity \
   --host <hub_ip> --port 5678 --siteid solver
 ```
 
-There is no way to pass credentials inline — the identity file is the only source.
+There is no way to pass credentials inline. The identity file is the only source.
+
+---
+[← Solver integration](solver_integration.md) · [Home](../README.md)

--- a/docs/solver_integration.md
+++ b/docs/solver_integration.md
@@ -70,3 +70,6 @@ class: ovos_hivemind_solver.HiveMindSolver
 
 The `neon.plugin.solver` group is the standard solver entry point shared across OVOS
 and compatible frameworks.
+
+---
+[Home](../README.md) · [Configuration →](configuration.md)


### PR DESCRIPTION
Rewrites README.md and the two docs pages for clarity and consistency, using Simplified Technical English. Adds a navigation footer between docs/solver_integration.md and docs/configuration.md and links each back to the README. No facts, features, or claims were added or removed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved punctuation and formatting across the README and configuration guide.
  * Added clearer table formatting and navigation links between related documentation sections.
  * Enhanced connection identity guidance with improved readability and page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->