### PR TITLE
fix: require a v3-Noise-capable hivemind_bus_client (>=1.0.16a1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-plugin-manager>=2.1.0,<3.0.0
 ovos-translate-server-plugin
-hivemind_bus_client>=0.0.4a21
+hivemind_bus_client>=1.0.16a1


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

A v3-Noise-only HiveMind core requires every client to complete the Noise handshake, which first shipped in `hivemind_bus_client` 0.9.2a4. `requirements.txt` pinned `hivemind_bus_client>=0.0.4a21`, far below that floor -- a constrained/pinned install could resolve a pre-Noise client unable to connect to a v3-only core.

The plugin connects via `HiveMessageBusClient(useragent=...)` with no explicit credentials, i.e. it uses the default NodeIdentity/identity file, which already carries the password -- that path is fine for v3 Noise and needed no code change. The keepalive TypeError-swallow in `ovos_hivemind_solver/__init__.py` (defensive against pre-keepalive-kwargs constructor signatures) is left as-is.

## Change
Bumped the floor in `requirements.txt` from `hivemind_bus_client>=0.0.4a21` to `hivemind_bus_client>=1.0.16a1`, aligning with the current bridge line and guaranteeing both v3 Noise and the websocket keepalive kwargs the code already tries to use.

## Test plan
- Full suite: 9 passed, resolving `hivemind_bus_client==1.0.20a1`.